### PR TITLE
refactor: use react-router Link for Header navigation

### DIFF
--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { Subheading } from "./Subheading";
 import { useUser, emitAuthChange } from "../hooks/useUser";
 
@@ -30,11 +30,7 @@ const Header = () => {
     navigate("/login");
   };
 
-  const navigateTo = (path: string) => {
-    navigate(path);
-  };
-
-  const getNavButtonClass = (path: string): string => {
+  const getNavLinkClass = (path: string): string => {
     return `transition-colors duration-200 ${
       location.pathname === path
         ? "text-letterboxd-text-primary"
@@ -45,49 +41,34 @@ const Header = () => {
   return (
     <header>
       <div className="max-w-5xl mx-auto flex justify-between items-center">
-        <button
-          onClick={() => navigateTo("/")}
+        <Link
+          to="/"
           className="text-2xl text-left font-bold text-letterboxd-text-primary hover:text-letterboxd-accent transition-colors duration-200"
         >
           <span>The Big Picture Discord</span>
           <Subheading />
-        </button>
+        </Link>
 
         {/* Desktop Navigation */}
         <div className="hidden md:flex items-center space-x-4">
-          {/* <button
-            onClick={() => navigateTo("/mfl")}
-            className={getNavButtonClass("/mfl")}
-          >
-            MFL
-          </button> */}
-          <button
-            onClick={() => navigateTo("/compare")}
-            className={getNavButtonClass("/compare")}
-          >
+          <Link to="/compare" className={getNavLinkClass("/compare")}>
             Compare
-          </button>
-          <button
-            onClick={() => navigateTo("/hater-rankings")}
-            className={getNavButtonClass("/hater-rankings")}
+          </Link>
+          <Link
+            to="/hater-rankings"
+            className={getNavLinkClass("/hater-rankings")}
           >
             Hater Rankings
-          </button>
+          </Link>
 
           {profilePath && (
-            <button
-              onClick={() => navigateTo(profilePath)}
-              className={getNavButtonClass(profilePath)}
-            >
+            <Link to={profilePath} className={getNavLinkClass(profilePath)}>
               Profile
-            </button>
+            </Link>
           )}
-          <button
-            onClick={() => navigateTo("/fetcher")}
-            className={getNavButtonClass("/fetcher")}
-          >
+          <Link to="/fetcher" className={getNavLinkClass("/fetcher")}>
             Data Fetcher
-          </button>
+          </Link>
 
           {isAuthenticated ? (
             <button onClick={handleLogout} className="btn-secondary">
@@ -95,18 +76,12 @@ const Header = () => {
             </button>
           ) : (
             <div className="flex gap-2">
-              <button
-                onClick={() => navigateTo("/login")}
-                className="btn-secondary"
-              >
+              <Link to="/login" className="btn-secondary">
                 Login
-              </button>
-              <button
-                onClick={() => navigateTo("/signup")}
-                className="btn-primary"
-              >
+              </Link>
+              <Link to="/signup" className="btn-primary">
                 Sign Up
-              </button>
+              </Link>
             </div>
           )}
         </div>
@@ -139,48 +114,48 @@ const Header = () => {
       {isMobileMenuOpen && (
         <div className="md:hidden border-t border-letterboxd-border bg-letterboxd-bg-secondary">
           <div className="px-6 py-4 space-y-4">
-            <button
-              onClick={() => navigateTo("/compare")}
-              className={`block w-full text-left py-2 ${getNavButtonClass(
+            <Link
+              to="/compare"
+              className={`block w-full text-left py-2 ${getNavLinkClass(
                 "/compare",
               )}`}
             >
               Compare
-            </button>
-            <button
-              onClick={() => navigateTo("/hater-rankings")}
-              className={`block w-full text-left py-2 ${getNavButtonClass(
+            </Link>
+            <Link
+              to="/hater-rankings"
+              className={`block w-full text-left py-2 ${getNavLinkClass(
                 "/hater-rankings",
               )}`}
             >
               Hater Rankings
-            </button>
-            <button
-              onClick={() => navigateTo("/dashboard")}
-              className={`block w-full text-left py-2 ${getNavButtonClass(
+            </Link>
+            <Link
+              to="/dashboard"
+              className={`block w-full text-left py-2 ${getNavLinkClass(
                 "/dashboard",
               )}`}
             >
               Dashboard
-            </button>
+            </Link>
             {profilePath && (
-              <button
-                onClick={() => navigateTo(profilePath)}
-                className={`block w-full text-left py-2 ${getNavButtonClass(
+              <Link
+                to={profilePath}
+                className={`block w-full text-left py-2 ${getNavLinkClass(
                   profilePath,
                 )}`}
               >
                 Profile
-              </button>
+              </Link>
             )}
-            <button
-              onClick={() => navigateTo("/fetcher")}
-              className={`block w-full text-left py-2 ${getNavButtonClass(
+            <Link
+              to="/fetcher"
+              className={`block w-full text-left py-2 ${getNavLinkClass(
                 "/fetcher",
               )}`}
             >
               Data Fetcher
-            </button>
+            </Link>
 
             <div className="pt-2 border-t border-letterboxd-border space-y-2">
               {isAuthenticated ? (
@@ -189,18 +164,18 @@ const Header = () => {
                 </button>
               ) : (
                 <>
-                  <button
-                    onClick={() => navigateTo("/login")}
-                    className="btn-secondary w-full"
+                  <Link
+                    to="/login"
+                    className="btn-secondary w-full block text-center"
                   >
                     Login
-                  </button>
-                  <button
-                    onClick={() => navigateTo("/signup")}
-                    className="btn-primary w-full"
+                  </Link>
+                  <Link
+                    to="/signup"
+                    className="btn-primary w-full block text-center"
                   >
                     Sign Up
-                  </button>
+                  </Link>
                 </>
               )}
             </div>


### PR DESCRIPTION
## What

Converts the Header's navigating `<button onClick={() => navigate(...)}>` elements to react-router `<Link>` — across **both the desktop nav and the mobile menu**: brand logo, Compare, Hater Rankings, Profile, Data Fetcher, Dashboard, Login, Sign Up.

## Why

These are navigations, so `<a href>` is the semantically correct element. Real anchors give us, for free, what `button + navigate()` doesn't:
- keyboard + assistive-tech announce them as links
- middle-click / cmd-click → open in new tab
- right-click → copy link / open in new window
- hover shows the destination URL

SPA client-side routing is preserved (verified: clicking a Link navigates without a full page reload).

## What stays a `<button>`
- **Logout** — a side-effecting action (clears storage, emits authchange), not a navigation.
- **Hamburger toggle** — toggles menu state.

## Notes
- Removed the now-unused `navigateTo` helper; renamed `getNavButtonClass` → `getNavLinkClass`.
- Mobile auth links get `block text-center` because `<a>` is `display: inline` by default (unlike `<button>`'s inline-block), so `w-full` wouldn't otherwise apply — this preserves the full-width button appearance.

## Verification
- ✅ `tsc` clean, `vite build` passes, 290 tests pass.
- ✅ In-browser: header renders identically; nav items are now `<a href>` (confirmed via DOM); only the hamburger remains a `<button>`; client-side navigation confirmed (no full reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)